### PR TITLE
Add meson build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,58 @@
+project('lpm',
+    ['c'],
+    version : '1.0.4',
+    license : 'LPM',
+    meson_version : '>= 0.56',
+)
+
+cc = meson.get_compiler('c')
+
+zlib_dep = dependency('zlib')
+mbedtls_dep = dependency('mbedtls', required: false)
+libgit2_dep = dependency('libgit2')
+libzip_dep = dependency('libzip')
+lua_dep = dependency('lua')
+microtar_dep = dependency('microtar', required: false)
+
+if not mbedtls_dep.found()
+    mbedtls_dep = [
+        cc.find_library('mbedtls'),
+        cc.find_library('mbedx509'),
+        cc.find_library('mbedcrypto'),
+    ]
+endif
+
+if not microtar_dep.found()
+    microtar_lib = static_library('microtar', files('lib/microtar/src/microtar.c'))
+
+    microtar_dep = declare_dependency(
+        link_whole: [microtar_lib],
+        include_directories: ['lib/microtar/src']
+    )
+
+    message('Using git module for microtar')
+endif
+
+lpm_source = files('src/lpm.c')
+cargs = []
+if get_option('static')
+    lua_exe = find_program('lua')
+    xxd_exe = find_program('xxd')
+
+    lpm_luac = configure_file(
+        capture: false,
+        command: [lua_exe, '-e', 'io.open("@OUTPUT0@", "wb"):write(string.dump(assert(loadfile("@INPUT0@"))))'],
+        input: files('src/lpm.lua'),
+        output: 'lpm.luac'
+    )
+
+    lpm_source += configure_file(
+        capture: true,
+        command: [xxd_exe, '-i', '@INPUT@'],
+        input: lpm_luac,
+        output: 'lpm.lua.c'
+    )
+
+endif
+
+executable('lpm', lpm_source, dependencies: [zlib_dep, mbedtls_dep, libgit2_dep, libzip_dep, lua_dep, microtar_dep])

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('static', type : 'boolean', value : false, description: 'Build the pre-packaged lua file into the executable.')


### PR DESCRIPTION
closes #23

Checks for all dependencies using cmake or pkg-config except:
mbedtls is also checked for using find_libary
microtar is used from the git module if not found