### PR TITLE
Revert "Set variable name with xxd instead of relying on path"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ fi
 if [[ "$@" == *"-DLPM_STATIC"* ]]; then
   [[ ! -e "lua.exe" ]] && gcc -Ilib/lua -o lua.exe lib/lua/onelua.c -lm
   ./lua.exe -e 'io.open("src/lpm.luac", "wb"):write(string.dump(assert(loadfile("src/lpm.lua"))))'
-  xxd -n lpm_luac -i src/lpm.luac > src/lpm.lua.c
+  xxd -i src/lpm.luac > src/lpm.lua.c
 fi
 
 [[ $OSTYPE != 'msys'* && $CC != *'mingw'* && $CC != "emcc" ]] && CFLAGS="$CFLAGS -DLUA_USE_LINUX" && LDFLAGS="$LDFLAGS -ldl"

--- a/meson.build
+++ b/meson.build
@@ -34,7 +34,7 @@ if not microtar_dep.found()
 endif
 
 lpm_source = files('src/lpm.c')
-cflags = []
+cargs = []
 if get_option('static')
     lua_exe = find_program('lua')
     xxd_exe = find_program('xxd')
@@ -48,17 +48,11 @@ if get_option('static')
 
     lpm_source += configure_file(
         capture: true,
-        command: [xxd_exe, '-n', 'lpm_luac', '-i', '@INPUT@'],
+        command: [xxd_exe, '-i', '@INPUT@'],
         input: lpm_luac,
         output: 'lpm.lua.c'
     )
 
-    cflags += '-DLPM_STATIC'
-
 endif
 
-executable('lpm',
-    lpm_source,
-    dependencies: [zlib_dep, mbedtls_dep, libgit2_dep, libzip_dep, lua_dep, microtar_dep],
-    c_args: cflags
-)
+executable('lpm', lpm_source, dependencies: [zlib_dep, mbedtls_dep, libgit2_dep, libzip_dep, lua_dep, microtar_dep])

--- a/src/lpm.c
+++ b/src/lpm.c
@@ -1133,8 +1133,8 @@ static const luaL_Reg system_lib[] = {
 
 
 #ifdef LPM_STATIC
-  extern const char lpm_luac[];
-  extern unsigned int lpm_luac_len;
+  extern const char src_lpm_luac[];
+  extern unsigned int src_lpm_luac_len;
 #endif
 
 int main(int argc, char* argv[]) {
@@ -1165,7 +1165,7 @@ int main(int argc, char* argv[]) {
   #ifndef LPM_STATIC
   if (luaL_loadfile(L, "src/lpm.lua") || lua_pcall(L, 0, 1, 0)) {
   #else
-  if (luaL_loadbuffer(L, lpm_luac, lpm_luac_len, "lpm.lua") || lua_pcall(L, 0, 1, 0)) {
+  if (luaL_loadbuffer(L, src_lpm_luac, src_lpm_luac_len, "lpm.lua") || lua_pcall(L, 0, 1, 0)) {
   #endif
     fprintf(stderr, "internal error when starting the application: %s\n", lua_tostring(L, -1));
     return -1;


### PR DESCRIPTION
Reverts lite-xl/lite-xl-plugin-manager#25

Breaks CI, because -n doesn't exist. 