### PR TITLE
Improve `mbedtls2` detection in meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,18 +8,29 @@ project('lpm',
 cc = meson.get_compiler('c')
 
 zlib_dep = dependency('zlib')
-mbedtls_dep = dependency('mbedtls', required: false)
+mbedtls_dep = dependency('mbedtls', version: '<3', required: false)
 libgit2_dep = dependency('libgit2')
 libzip_dep = dependency('libzip')
 lua_dep = dependency('lua')
 microtar_dep = dependency('microtar', required: false)
 
 if not mbedtls_dep.found()
-    mbedtls_dep = [
-        cc.find_library('mbedtls'),
-        cc.find_library('mbedx509'),
-        cc.find_library('mbedcrypto'),
-    ]
+    # Using has_headers to distinguish between mbedtls2 and mbedtls3
+    _mbedtls_dep = cc.find_library('mbedtls', has_headers: 'mbedtls/net.h', required: false)
+    if _mbedtls_dep.found()
+        mbedtls_dep = [
+            _mbedtls_dep,
+            cc.find_library('mbedx509'),
+            cc.find_library('mbedcrypto'),
+        ]
+    else
+        # In some cases we need to manually specify where to find mbedtls2
+        message('Using fallback mbedtls definition')
+        mbedtls_dep = declare_dependency(
+            include_directories: ['/usr/include/mbedtls2/'],
+            link_args: ['-L/usr/lib/mbedtls2', '-lmbedtls', '-lmbedx509', '-lmbedcrypto']
+        )
+    endif
 endif
 
 if not microtar_dep.found()


### PR DESCRIPTION
In distros that ship both `mbedtls3` and `mbedtls2` (like Arch) this tried to compile with `mbedtls3`, failing.

This PR tries to check that we're using the correct version, and defines a fallback (that likely only works in some distros - tested on Arch).

This is needed for the `lpm-git` AUR package.

@Jan200101 Does this make sense?