### PR TITLE
Fix Windows install issues

### DIFF
--- a/src/lpm.lua
+++ b/src/lpm.lua
@@ -1369,7 +1369,7 @@ function Bottle:construct()
   end
   -- atomically move things
   common.rmrf(local_path)
-  common.mkdirp(local_path)
+  common.mkdirp(common.dirname(local_path))
   common.rename(self.local_path, local_path)
   self.local_path = local_path
 end

--- a/src/lpm.lua
+++ b/src/lpm.lua
@@ -1383,7 +1383,7 @@ end
 function Bottle:run(args)
   args = args or {}
   if self.is_system then error("system bottle cannot be run") end
-  local path = self.local_path .. PATHSEP .. "lite-xl"
+  local path = self.local_path .. PATHSEP .. "lite-xl" .. EXECUTABLE_EXTENSION
   if not system.stat(path) then error("cannot find bottle executable " .. path) end
   os.execute(path .. (#args > 0 and " " or "") .. table.concat(args, " "))
 end


### PR DESCRIPTION
Fixes #74.

Creating the destination path results in `common.rename` to move the source files to `dst/src_basename`, which results in the double hash found in #74, that majorly reduces our path size possibilities on Windows.

It looks like this also needed `.exe` in `Bottle:run` on Windows.