### PR TITLE
cJSON Addition

### DIFF
--- a/libraries/json.lua
+++ b/libraries/json.lua
@@ -385,5 +385,12 @@ function json.decode(str)
   return res
 end
 
+local status, cjson = pcall(require, "libraries.cjson")
+if status then
+  json.ldecode = json.decode
+  json.lencode = json.encode
+  json.decode = cjson.decode
+  json.encode = cjson.encode
+end
 
 return json

--- a/libraries/json.lua
+++ b/libraries/json.lua
@@ -385,7 +385,7 @@ function json.decode(str)
   return res
 end
 
-local status, cjson = pcall(require, "libraries.cjson")
+local status, cjson = pcall(require, "libraries.json.cjson")
 if status then
   json.ldecode = json.decode
   json.lencode = json.encode

--- a/manifest.json
+++ b/manifest.json
@@ -81,7 +81,33 @@
       "version": "1.0",
       "description": "JSON support plugin, provides encoding/decoding.",
       "type": "library",
-      "path": "libraries/json.lua"
+      "path": "libraries/json.lua",
+      "files": [
+        {
+          "arch": "x86_64-linux",
+          "url": "https://github.com/adamharrison/lite-xl-cjson/releases/download/latest/cjson.x86_64-linux.so",
+          "checksum": "e8aa584aa9478e2d6ddaf3659c5c7916b7eda8ad3d61e615dc6369ec359ad89e",
+          "optional": true
+        },
+        {
+          "arch": "x86_64-windows",
+          "url": "https://github.com/adamharrison/lite-xl-cjson/releases/download/latest/cjson.x86_64-windows.dll",
+          "checksum": "5c7558e3c00a3a5c6ebc2f03bba2ceb5641e7c5efe186a643062c72f5918cd80",
+          "optional": true
+        },
+        {
+          "arch": "x86_64-darwin",
+          "url": "https://github.com/adamharrison/lite-xl-cjson/releases/download/latest/cjson.x86_64-darwin.so",
+          "checksum": "4eb4b2e347660c4872ce294853516de16463b85f32560bf4a3b1532a0cc6cafc",
+          "optional": true
+        },
+        {
+          "arch": "aarch64-darwin",
+          "url": "https://github.com/adamharrison/lite-xl-cjson/releases/download/latest/cjson.aarch64-darwin.so",
+          "checksum": "7291983bc5b8bf26b7f5b63b9e0a9bf6cf56ce1e5d2813210083ddbc11793e40",
+          "optional": true
+        }
+      ]
     }
   ],
   "lite-xls": [


### PR DESCRIPTION
Modifies the json library so `cJSON` is used by default.

This is included as an optional library file to be included if people want into the `json` library. For the relevant architectures, it should provide much improved encoding/decoding capabilities.