### PR TITLE
ci: parallelize most build processes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,14 +107,14 @@ jobs:
           name: ${{ env.BIN }}
 
   build-macos:
-    runs-on: macos-11
-    env: { CC: clang }
-
     strategy:
       matrix:
         config:
-          - { arch: x86_64, llvm: x86_64 }
-          - { arch: aarch64, llvm: arm64 }
+          - { arch: x86_64, runner: macos-13 } # macos-13 runs on Intel runners
+          - { arch: aarch64, runner: macos-14 } # macos-14 runs on M1 runners
+
+    runs-on: ${{ matrix.config.runner }}
+    env: { CC: clang }
 
     steps:
       - name: Checkout code
@@ -132,7 +132,7 @@ jobs:
 
       - name: Build
         run: |
-          ./build.sh clean && CFLAGS="-arch ${{ matrix.config.llvm }}" ./build.sh -DLPM_STATIC -DLPM_VERSION='"'$FULL_VERSION-$ARCH'"' -O3
+          ./build.sh clean && ./build.sh -DLPM_STATIC -DLPM_VERSION='"'$FULL_VERSION-$ARCH'"' -O3
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,40 +1,97 @@
 name: CI
-on: { push: { branches: [master] } }
+on:
+  push: { branches: [master] }
+  workflow_dispatch:
+
 jobs:
-  build_linux_android_windows:
+  build:
     runs-on: ubuntu-latest
-    environment: Release
-    defaults: { run: { shell: bash } }
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { platform: linux, arch: x86_64, native: true }
+          - { platform: linux, arch: aarch64, native: false }
+          - { platform: linux, arch: riscv64, native: false }
+          - { platform: windows, arch: x86_64, suffix: .exe, native: false }
+          - { platform: android, arch: arm, abi: armeabi-v7a, llvm: armv7a, eabi: eabi, native: false }
+          - { platform: android, arch: aarch64, abi: arm64-v8a, llvm: aarch64, native: false }
+          - { platform: android, arch: x86_64, abi: x86_64, llvm: x86_64, native: false }
+          - { platform: android, arch: x86, abi: x86, llvm: i686, native: false }
+
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
-        with: { fetch-depth: 0 }
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+
       - name: Set Environment Variables
         run: |
-          git config --global user.name "Github Actions" && git config --global user.email "adamdharrison@gmail.com"
-          echo VERSION=`git describe --tags --abbrev=0 --match "v*" | tail -c +2` >> $GITHUB_ENV && echo FULL_VERSION=`git describe --tags --match "v*" | tail -c +2` >> $GITHUB_ENV && echo REV=$((`git describe --tags  --match "v*" | sed 's/.*-\([0-9]*\)-.*/\1/' | sed s/^v.*//` + 1)) >> $GITHUB_ENV
-      - name: Clone Submodules
-        run: git submodule update --init --depth=1
-      - name: Build Linux
+          echo VERSION=`git describe --tags --abbrev=0 --match "v*" | tail -c +2` >> $GITHUB_ENV
+          echo FULL_VERSION=`git describe --tags --match "v*" | tail -c +2` >> $GITHUB_ENV
+          echo ARCH=${{ matrix.config.arch }}-${{ matrix.config.platform }} >> $GITHUB_ENV
+          echo BIN=lpm.${{ matrix.config.arch }}-${{ matrix.config.platform }}${{ matrix.config.suffix }} >> $GITHUB_ENV
+          echo HOSTCC=gcc >> $GITHUB_ENV
+
+      - name: Setup (Linux)
+        if: ${{ matrix.config.platform == 'linux' && matrix.config.native }}
         run: |
-          sudo apt-get install musl-tools musl musl-dev
-          wget -q https://musl.cc/riscv64-linux-musl-cross.tgz && tar -zxvf riscv64-linux-musl-cross.tgz
-          wget -q https://musl.cc/aarch64-linux-musl-cross.tgz && tar -zxvf aarch64-linux-musl-cross.tgz
-          ./build.sh clean && BIN=lpm.riscv64-linux HOSTCC=gcc CC=`pwd`/riscv64-linux-musl-cross/bin/riscv64-linux-musl-cc AR=`pwd`/riscv64-linux-musl-cross/bin/riscv64-linux-musl-ar ./build.sh -DLPM_STATIC -DLPM_VERSION='"'$FULL_VERSION-riscv64-linux'"' -static -O3
-          ./build.sh clean && BIN=lpm.aarch64-linux HOSTCC=gcc CC=`pwd`/aarch64-linux-musl-cross/bin/aarch64-linux-musl-cc AR=`pwd`/aarch64-linux-musl-cross/bin/aarch64-linux-musl-ar ./build.sh -DLPM_STATIC -DLPM_VERSION='"'$FULL_VERSION-aarch64-linux'"' -static -O3
-          ./build.sh clean && BIN=lpm.x86_64-linux CC=musl-gcc ./build.sh -DLPM_STATIC -DLPM_VERSION='"'$FULL_VERSION-x86_64-linux'"' -static -O3
-      - name: Run Tests
+          sudo apt-get update && sudo apt-get install musl-tools musl musl-dev
+          echo CC=musl-gcc >> $GITHUB_ENV
+
+      - name: Setup (Linux cross-compilation)
+        if: ${{ matrix.config.platform == 'linux' && ! matrix.config.native }}
         run: |
-          cp ./lpm.x86_64-linux lpm && ./lpm test t/run.lua
-      - name: Build Android
+          wget -q https://musl.cc/${{ matrix.config.arch }}-linux-musl-cross.tgz
+          tar -zxvf ${{ matrix.config.arch }}-linux-musl-cross.tgz
+          echo CC=$(pwd)/${{ matrix.config.arch }}-linux-musl-cross/bin/${{ matrix.config.arch }}-linux-musl-cc >> $GITHUB_ENV
+          echo AR=$(pwd)/${{ matrix.config.arch }}-linux-musl-cross/bin/${{ matrix.config.arch }}-linux-musl-ar >> $GITHUB_ENV
+
+      - name: Setup (Windows)
+        if: ${{ matrix.config.platform == 'windows' }}
+        run: |
+          sudo apt-get update && sudo apt-get install mingw-w64
+          CMAKE_DEFAULT_FLAGS=(
+            "-DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER"
+            "-DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=NEVER" "-DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=NEVER"
+            "-DCMAKE_POSITION_INDEPENDENT_CODE=ON" "-DCMAKE_SYSTEM_NAME=Windows"
+            "-DCMAKE_SYSTEM_INCLUDE_PATH=/usr/share/mingw-w64/include"
+          )
+          echo "CMAKE_DEFAULT_FLAGS=${CMAKE_DEFAULT_FLAGS[*]}" >> $GITHUB_ENV
+          echo "LZMA_CONFIGURE=--host=x86_64-w64-mingw32" >> $GITHUB_ENV
+          echo "GIT2_CONFIGURE=-DDLLTOOL=x86_64-w64-mingw32-dlltool" >> $GITHUB_ENV
+          echo CC=x86_64-w64-mingw32-gcc >> $GITHUB_ENV
+          echo AR=x86_64-w64-mingw32-gcc-ar >> $GITHUB_ENV
+          echo WINDRES=x86_64-w64-mingw32-windres >> $GITHUB_ENV
+
+      - name: Setup (Android)
+        if: ${{ matrix.config.platform == 'android' }}
         env: { ANDROID_ABI_VERSION: "26" }
         run: |
-          export CMAKE_DEFAULT_FLAGS="-DCMAKE_ANDROID_NDK=$ANDROID_NDK_HOME -DCMAKE_ANDROID_API=$ANDROID_ABI_VERSION -DCMAKE_SYSTEM_VERSION=$ANDROID_ABI_VERSION -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=NEVER -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=NEVER -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_INCLUDE_PATH=$ANDROID_SYSROOT_NDK/sysroot/usr/include"
-          export AR="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar"
-          ./build.sh clean && export ARCH="arm-android" &&     CFLAGS="-Dinline=" BIN=lpm.$ARCH CMAKE_DEFAULT_FLAGS="$CMAKE_DEFAULT_FLAGS -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a" HOSTCC=gcc CC=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi$ANDROID_ABI_VERSION-clang   ./build.sh -DLPM_VERSION='"'$FULL_VERSION-$ARCH'"' -DLPM_STATIC
-          ./build.sh clean && export ARCH="aarch64-android" && CFLAGS="-Dinline=" BIN=lpm.$ARCH CMAKE_DEFAULT_FLAGS="$CMAKE_DEFAULT_FLAGS -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a"   HOSTCC=gcc CC=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android$ANDROID_ABI_VERSION-clang      ./build.sh -DLPM_VERSION='"'$FULL_VERSION-$ARCH'"' -DLPM_STATIC
-          ./build.sh clean && export ARCH="x86-android" &&     CFLAGS="-Dinline=" BIN=lpm.$ARCH CMAKE_DEFAULT_FLAGS="$CMAKE_DEFAULT_FLAGS -DCMAKE_ANDROID_ARCH_ABI=x86"         HOSTCC=gcc CC=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android$ANDROID_ABI_VERSION-clang         ./build.sh -DLPM_VERSION='"'$FULL_VERSION-$ARCH'"' -DLPM_STATIC
-          ./build.sh clean && export ARCH="x86_64-android" &&  CFLAGS="-Dinline=" BIN=lpm.$ARCH CMAKE_DEFAULT_FLAGS="$CMAKE_DEFAULT_FLAGS -DCMAKE_ANDROID_ARCH_ABI=x86_64"      HOSTCC=gcc CC=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android$ANDROID_ABI_VERSION-clang       ./build.sh -DLPM_VERSION='"'$FULL_VERSION-$ARCH'"' -DLPM_STATIC
+          LLVM_BIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          CMAKE_DEFAULT_FLAGS=(
+            "-DCMAKE_ANDROID_NDK=$ANDROID_NDK_HOME"
+            "-DCMAKE_ANDROID_API=$ANDROID_ABI_VERSION" "-DCMAKE_SYSTEM_VERSION=$ANDROID_ABI_VERSION"
+            "-DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=NEVER" "-DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=NEVER"
+            "-DCMAKE_SYSTEM_NAME=Android" "-DCMAKE_SYSTEM_INCLUDE_PATH=$ANDROID_SYSROOT_NDK/sysroot/usr/include"
+            "-DCMAKE_ANDROID_ARCH_ABI=${{ matrix.config.abi }}"
+          )
+          echo "CMAKE_DEFAULT_FLAGS=${CMAKE_DEFAULT_FLAGS[*]}" >> $GITHUB_ENV
+          echo "AR=$LLVM_BIN/llvm-ar" >> $GITHUB_ENV
+          echo "CC=$LLVM_BIN/${{ matrix.config.llvm }}-linux-android${{ matrix.config.eabi }}$ANDROID_ABI_VERSION-clang" >> $GITHUB_ENV
+          echo "CFLAGS=-Dinline=" >> $GITHUB_ENV
+
+      - name: Build
+        run: |
+          ./build.sh clean && ./build.sh -DLPM_STATIC -DLPM_VERSION='"'$FULL_VERSION-$ARCH'"' -static -O3
+
+      - name: Run Tests
+        if: ${{ matrix.config.native }}
+        run: |
+          cp $BIN lpm && ./lpm test t/run.lua
+
       # - name: Package Debian/Ubuntu
       #   env: { ARCH: "amd64", DESCRIPTION: "A plugin manager for the lite-xl text editor.", MAINTAINER: "Adam Harrison <adamdharrison@gmail.com>" }
       #   run: |
@@ -42,52 +99,79 @@ jobs:
       #     mkdir -p $NAME/usr/bin $NAME/DEBIAN && cp lpm $NAME/usr/bin
       #     printf "Package: lpm\nVersion: $VERSION\nArchitecture: $ARCH\nMaintainer: $MAINTAINER\nDescription: $DESCRIPTION\n" > $NAME/DEBIAN/control
       #     dpkg-deb --build --root-owner-group $NAME
-      - name: Build Windows
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: ${{ env.BIN }}
+          name: ${{ env.BIN }}
+
+  build-macos:
+    runs-on: macos-11
+    env: { CC: clang }
+
+    strategy:
+      matrix:
+        config:
+          - { arch: x86_64, llvm: x86_64 }
+          - { arch: aarch64, llvm: arm64 }
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Set Environment Variables
         run: |
-          sudo apt-get install mingw-w64 && ./build.sh clean && BIN=lpm.x86_64-windows.exe HOSTCC=gcc CC=x86_64-w64-mingw32-gcc AR=x86_64-w64-mingw32-gcc-ar WINDRES=x86_64-w64-mingw32-windres CMAKE_DEFAULT_FLAGS="-DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=NEVER -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=NEVER -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_INCLUDE_PATH=/usr/share/mingw-w64/include" LZMA_CONFIGURE="--host=x86_64-w64-mingw32" GIT2_CONFIGURE="-DDLLTOOL=x86_64-w64-mingw32-dlltool" ./build.sh -DLPM_STATIC -DLPM_VERSION='"'$VERSION-x86_64-windows'"' -O3
+          echo VERSION=`git describe --tags --abbrev=0  --match "v*" | tail -c +2` >> $GITHUB_ENV
+          echo REV=$((`git describe --tags  --match "v*" | sed 's/.*-\([0-9]*\)-.*/\1/' | sed s/^v.*//` + 1)) >> $GITHUB_ENV
+          echo ARCH=${{ matrix.config.arch }}-darwin >> $GITHUB_ENV
+          echo BIN=lpm.${{ matrix.config.arch }}-darwin >> $GITHUB_ENV
+
+      - name: Build
+        run: |
+          ./build.sh clean && CFLAGS="-arch ${{ matrix.config.llvm }}" ./build.sh -DLPM_STATIC -DLPM_VERSION='"'$FULL_VERSION-$ARCH'"' -O3
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: ${{ env.BIN }}
+          name: ${{ env.BIN }}
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [build, build-macos]
+    env: { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set Environment Variables
+        run: |
+          echo VERSION=`git describe --tags --abbrev=0 --match "v*" | tail -c +2` >> $GITHUB_ENV
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: lpm.*
+          path: artifacts
+          merge-multiple: true
+
       - name: Create Release(s)
-        env: { GITHUB_TOKEN: "${{ github.token }}", ARTIFACTS: "lpm.x86_64-linux lpm.aarch64-linux lpm.riscv64-linux lpm.x86_64-windows.exe lpm.arm-android lpm.aarch64-android lpm.x86-android lpm.x86_64-android" }
         run: |
           perl -pe 'last if $_ =~ m/^\s*#/ && $_ !~ m/#\s*$ENV{VERSION}/' < CHANGELOG.md | tail -n +2 > NOTES.md
-          gh release delete -y continuous || true; gh release create -t 'Continuous Release' -F NOTES.md continuous $ARTIFACTS
+          gh release delete -y continuous || true;
+          gh release create -t 'Continuous Release' -F NOTES.md continuous ./artifacts/*
           if [[ `git tag --points-at HEAD v* | head -c 1` == "v" ]]; then
             gh release delete -y v$VERSION || true;
-            gh release create -t v$VERSION -F NOTES.md v$VERSION $ARTIFACTS
+            gh release create -t v$VERSION -F NOTES.md v$VERSION ./artifacts/*
             gh release delete -y latest || true;
-            gh release create -t latest -F NOTES.md latest $ARTIFACTS
-          fi
-      - name: Discord Notification
-        env: { DISCORD_WEBHOOK: "${{ secrets.DISCORD_WEBHOOK }}" }
-        run: |
-          if [[ `git tag --points-at HEAD v* | head -c 1` == "v" ]]; then
-            perl -e 'use JSON qw(encode_json from_json); $/ = undef; print encode_json({ content => "## Lite XL Plugin Manager $ENV{VERSION} has been released!\nhttps://github.com/lite-xl/lite-xl-plugin-manager/releases/tag/v$ENV{VERSION}\n@release:lpm\n### Changes in $ENV{VERSION}:\n" . <> })' < NOTES.md |
-              curl -H 'Content-Type:application/json' $DISCORD_WEBHOOK -X POST -d "$(</dev/stdin)"
-          fi
-
-  build_macos:
-    needs: build_linux_android_windows
-    runs-on: macos-11
-    env:
-      CC: clang
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-        with: { fetch-depth: 0 }
-      - name: Set Environment Variables
-        run: echo VERSION=`git describe --tags --abbrev=0  --match "v*" | tail -c +2` >> $GITHUB_ENV && echo FULL_VERSION=`git describe --tags --match "v*" | tail -c +2` >> $GITHUB_ENV && echo REV=$((`git describe --tags  --match "v*" | sed 's/.*-\([0-9]*\)-.*/\1/' | sed s/^v.*//` + 1)) >> $GITHUB_ENV
-      - name: Clone Submodules
-        run: git submodule update --init --depth=1
-      - name: Build MacOS
-        env: { GITHUB_TOKEN: "${{ github.token }}" }
-        run: |
-          ./build.sh clean && BIN=lpm.x86_64-darwin ./build.sh -DLPM_STATIC -DLPM_VERSION='"'$FULL_VERSION-x86_64-darwin'"' -O3
-          ./build.sh clean && BIN=lpm.aarch64-darwin CC=clang CFLAGS="-arch arm64" ./build.sh -DLPM_STATIC -DLPM_VERSION='"'$FULL_VERSION-aarch64-darwin'"' -O3
-          gh release upload continuous lpm.x86_64-darwin lpm.aarch64-darwin
-          if [[ `git tag --points-at HEAD v* | head -c 1` == "v" ]]; then
-            gh release upload v$VERSION lpm.x86_64-darwin
-            gh release upload latest lpm.x86_64-darwin
-            gh release upload v$VERSION lpm.aarch64-darwin
-            gh release upload latest lpm.aarch64-darwin
+            gh release create -t latest -F NOTES.md latest ./artifacts/*
             git branch -f latest HEAD
             git tag -f latest
             git push -f origin refs/heads/latest
@@ -96,3 +180,10 @@ jobs:
           git tag -f continuous
           git push -f origin refs/tags/continuous
 
+      - name: Discord Notification
+        env: { DISCORD_WEBHOOK: "${{ secrets.DISCORD_WEBHOOK }}" }
+        run: |
+          if [[ -n "$DISCORD_WEBHOOK" ]] && [[ `git tag --points-at HEAD v* | head -c 1` == "v" ]]; then
+            perl -e 'use JSON qw(encode_json from_json); $/ = undef; print encode_json({ content => "## Lite XL Plugin Manager $ENV{VERSION} has been released!\nhttps://github.com/lite-xl/lite-xl-plugin-manager/releases/tag/v$ENV{VERSION}\n@release:lpm\n### Changes in $ENV{VERSION}:\n" . <> })' < NOTES.md |
+              curl -H 'Content-Type:application/json' $DISCORD_WEBHOOK -X POST -d "$(</dev/stdin)"
+          fi


### PR DESCRIPTION
This PR does a few things:

1. added workflow_dispatch triggers in case you needed to test the workflow without pushing to master
2. parallelize a lot of build processes (this cut down the CI time by half, faster if macOS compilations is faster)
3. Check if the webhook URL exists so that the script doesn't error if it doesn't
4. Make it at least somewhat easier to add more build targets in the future

I have not tested the Android binaries - they are compiled with -O3 with all other targets. Other than that, I've tested the workflow with push to master tags, which seemed to work correctly.