### PR TITLE
lpm: allow dynamic loading even when LPM_STARTUP_SCRIPT envvar is set

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Build
         run: |
-          ./build.sh clean && ./build.sh -DLPM_STATIC -DLPM_VERSION='"'$FULL_VERSION-$ARCH'"' -static -O3
+          ./build.sh clean && ./build.sh -DLPM_STATIC -DLPM_STATIC_ALLOW_DYNAMIC_LOADING -DLPM_VERSION='"'$FULL_VERSION-$ARCH'"' -static -O3
 
       - name: Run Tests
         if: ${{ matrix.config.native }}
@@ -132,7 +132,7 @@ jobs:
 
       - name: Build
         run: |
-          ./build.sh clean && ./build.sh -DLPM_STATIC -DLPM_VERSION='"'$FULL_VERSION-$ARCH'"' -O3
+          ./build.sh clean && ./build.sh -DLPM_STATIC -DLPM_STATIC_ALLOW_DYNAMIC_LOADING -DLPM_VERSION='"'$FULL_VERSION-$ARCH'"' -O3
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/meson.build
+++ b/meson.build
@@ -56,6 +56,9 @@ if get_option('static')
         output: 'lpm.lua.c'
     )
     cflags += '-DLPM_STATIC'
+    if get_option('static_allow_dynamic_loading')
+        cflags += '-DLPM_STATIC_ALLOW_DYNAMIC_LOADING'
+    endif
 endif
 
 executable('lpm', lpm_source, dependencies: [zlib_dep, lzma_dep, mbedtls_dep, libgit2_dep, libzip_dep, lua_dep, microtar_dep], c_args: cflags)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('static', type : 'boolean', value : false, description: 'Build the pre-packaged lua file into the executable.')
+option('static_allow_dynamic_loading', type : 'boolean', value : true, description: 'When using static=true, allows lpm to load the lua file externally.')

--- a/src/lpm.c
+++ b/src/lpm.c
@@ -1841,8 +1841,13 @@ int main(int argc, char* argv[]) {
   lua_setglobal(L, "DEFAULT_REPO_URL");
   lua_pushliteral(L, LPM_DEFAULT_RELEASE);
   lua_setglobal(L, "DEFAULT_RELEASE_URL");
-  #ifndef LPM_STATIC
+  #if !defined(LPM_STATIC)
   if (luaL_loadfile(L, "src/lpm.lua") || lua_pcall(L, 0, 1, 0)) {
+  #elif defined(LPM_STATIC_ALLOW_DYNAMIC_LOADING)
+  if (
+    (getenv("LPM_STARTUP_SCRIPT") != NULL ? luaL_loadfile(L, getenv("LPM_STARTUP_SCRIPT")) : luaL_loadbuffer(L, lpm_luac, lpm_luac_len, "lpm.lua"))
+    || lua_pcall(L, 0, 1, 0)
+  ) {
   #else
   if (luaL_loadbuffer(L, lpm_luac, lpm_luac_len, "lpm.lua") || lua_pcall(L, 0, 1, 0)) {
   #endif


### PR DESCRIPTION
Implements #135.

Question:
1. Should we allow this behavior even when LPM_STATIC is unset?
2. Should this behavior be default?