### PR TITLE
Add option to install Lite-XL plugin

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -72,3 +72,13 @@ lpm_exe = executable('lpm',
     c_args: cflags,
     install: true,
 )
+
+if (get_option('install_plugin'))
+    lite_datadir = get_option('lite_datadir')
+    if lite_datadir == ''
+        # No path given, assume a default
+        lite_datadir = get_option('datadir') + '/lite-xl'
+    endif
+
+    install_subdir('plugins', install_dir : lite_datadir)
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,3 @@
 option('static', type : 'boolean', value : false, description: 'Build the pre-packaged lua file into the executable.')
+option('install_plugin', type : 'boolean', value : false, description: 'Install the Lite-XL plugin for lpm')
+option('lite_datadir', type : 'string', value : '', description: 'Path to the Lite-XL data directory, usually \'share/lite-xl\'')


### PR DESCRIPTION
If the user wants to install lpm they might also want to install the plugin for it
Defaults to off since lpm can be used standalone