### PR TITLE
fixed showing plugin list on windows

### DIFF
--- a/plugins/plugin_manager/init.lua
+++ b/plugins/plugin_manager/init.lua
@@ -124,7 +124,8 @@ local function run(cmd, options)
               has_chunk = true
             else
               still_running = false
-              if v[1]:returncode() == 0 then
+              local return_code = v[1]:returncode()
+              if return_code == 0 or return_code == nil then
                 progress_line, v[3] = extract_progress(v[3])
                 v[2]:resolve(v[3])
               else


### PR DESCRIPTION
On windows 11/lite-xl 2.1.5 plugin manager couldn't show plugin list because after ending of lpm process returncode() resolved to nil instead of 0 and went bad execution route