### PR TITLE
plugin: sorting, filtering, selection fixes

### DIFF
--- a/plugins/plugin_manager/plugin_view.lua
+++ b/plugins/plugin_manager/plugin_view.lua
@@ -435,7 +435,7 @@ keymap.add {
   ["home"]        = "plugin-manager:scroll-page-top",
   ["end"]         = "plugin-manager:scroll-page-bottom",
   ["lclick"]      = "plugin-manager:select",
-  ["ctrl+f"]      = "plugin-manager:find",
+  ["ctrl+f"]      = "plugin-manager:filter",
   ["ctrl+r"]      = "plugin-manager:refresh-all",
   ["ctrl+u"]      = "plugin-manager:upgrade-all",
   ["2lclick"]     = { "plugin-manager:install-selected", "plugin-manager:uninstall-selected" },

--- a/plugins/plugin_manager/plugin_view.lua
+++ b/plugins/plugin_manager/plugin_view.lua
@@ -226,7 +226,7 @@ function PluginView:draw()
   end
 
   local ox, oy = self:get_content_offset()
-  ox, oy = ox + style.padding.x, oy + self:get_table_content_offset()
+  oy = oy + self:get_table_content_offset()
   core.push_clip_rect(self.position.x, self.position.y + self:get_table_content_offset(), self.size.x, self.size.y)
   for i, plugin in ipairs(sorted_plugins) do
     local x, y = ox, oy

--- a/plugins/plugin_manager/plugin_view.lua
+++ b/plugins/plugin_manager/plugin_view.lua
@@ -348,6 +348,10 @@ command.add(PluginView, {
       suggest = on_filter
     })
   end,
+  ["plugin-manager:clear-filter"] = function()
+    plugin_view.filter_text = nil
+    plugin_view:refresh(true)
+  end,
   ["plugin-manager:scroll-page-up"] = function()
     plugin_view.scroll.to.y = math.max(plugin_view.scroll.y - plugin_view.size.y, 0)
   end,
@@ -439,7 +443,8 @@ keymap.add {
   ["ctrl+r"]      = "plugin-manager:refresh-all",
   ["ctrl+u"]      = "plugin-manager:upgrade-all",
   ["2lclick"]     = { "plugin-manager:install-selected", "plugin-manager:uninstall-selected" },
-  ["return"]      = { "plugin-manager:install-selected", "plugin-manager:uninstall-selected" }
+  ["return"]      = { "plugin-manager:install-selected", "plugin-manager:uninstall-selected" },
+  ["escape"]      = "plugin-manager:clear-filter",
 }
 
 

--- a/plugins/plugin_manager/plugin_view.lua
+++ b/plugins/plugin_manager/plugin_view.lua
@@ -345,7 +345,9 @@ command.add(PluginView, {
     end
     core.command_view:enter("Filter Plugins", {
       submit = on_filter,
-      suggest = on_filter
+      suggest = on_filter,
+      text = plugin_view.filter_text or "",
+      select_text = true
     })
   end,
   ["plugin-manager:clear-filter"] = function()

--- a/plugins/plugin_manager/plugin_view.lua
+++ b/plugins/plugin_manager/plugin_view.lua
@@ -115,6 +115,7 @@ end
 
 
 function PluginView:refresh(no_refetch, on_complete)
+  if self.loading then return end
   self.loading = true
   local function complete()
     self.loading = false


### PR DESCRIPTION
This ended up a bit larger than I think, so I would love to have another pair of eyes looking at this before getting it merged.

1. You can now sort the table. Since the icon font is very limited, we don't even have proper icons to indicate the sort order. Currently I draw a line and I think this is less intuitive than it shold've been.
2. You can also filter the table. This is different than "find" as it doesn't rely on the small CommandView preview section, and is generally a better UX. I think binding this as CTRL+F makes more sense than the current find-plugin, but I would like some more opinion on this.
3. Arrow up and down now works correctly.
