### PR TITLE
Update meson to use mbedtls3

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,35 +8,14 @@ cc = meson.get_compiler('c')
 
 zlib_dep = dependency('zlib')
 lzma_dep = dependency('liblzma')
-mbedtls_dep = dependency('mbedtls', version: '<3', required: false)
 libgit2_dep = dependency('libgit2')
 libzip_dep = dependency('libzip')
 lua_dep = dependency('lua')
-
-if mbedtls_dep.found()
-    mbedtls_dep = [
-        mbedtls_dep,
-        dependency('mbedx509', version: '<3', required: true),
-        dependency('mbedcrypto', version: '<3', required: true),
-    ]
-else
-    # Using has_headers to distinguish between mbedtls2 and mbedtls3
-    _mbedtls_dep = cc.find_library('mbedtls', has_headers: 'mbedtls/net.h', required: false)
-    if _mbedtls_dep.found()
-        mbedtls_dep = [
-            _mbedtls_dep,
-            cc.find_library('mbedx509'),
-            cc.find_library('mbedcrypto'),
-        ]
-    else
-        # In some cases we need to manually specify where to find mbedtls2
-        message('Using fallback mbedtls definition')
-        mbedtls_dep = declare_dependency(
-            include_directories: ['/usr/include/mbedtls2/'],
-            link_args: ['-L/usr/lib/mbedtls2', '-lmbedtls', '-lmbedx509', '-lmbedcrypto']
-        )
-    endif
-endif
+mbedtls_dep = [
+    dependency('mbedtls'),
+    dependency('mbedx509'),
+    dependency('mbedcrypto'),
+]
 
 microtar_lib = static_library('microtar', files('lib/microtar/src/microtar.c'))
 microtar_dep = declare_dependency(


### PR DESCRIPTION
- removes the version check from the dependency
- more distros switched to cmake for mbedtls so we can reliably use the pkgconf file